### PR TITLE
Make API client installable using pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ for item in response.data:
 
 ## Installation
 
+The code can be installed straight from GitHub using pip:
+
+```sh
+pip install https://github.com/altmetric/altmetric-explorer-api-client/tarball/main
+```
+
+...or by adding the url to your `requirements.txt` file and running `pip install -r requirements.txt`.
+
+## Getting Started
+
 A [docker compose](https://docs.docker.com/compose/) file is included to setup a development environment in docker that runs a Jupyter Labs server so you can experiment with the api.
 
 Start it by running:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = [
+    "setuptools >= 65",
+    "wheel >= 0.38"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "altmetric-explorer-api-client"
+version = "0.1.0"
+dynamic = ["dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools]
+packages = ['altmetric', 'altmetric.explorer', 'altmetric.explorer.api']


### PR DESCRIPTION
Adds the [project configuration](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/) needed to allow users to install the API client using `pip`.