### PR TITLE
Colab notebooks and recode URL

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,8 +5,7 @@ WORKDIR /app
 COPY requirements.txt requirements.dev.txt ./
 RUN pip install --upgrade pip && \
     pip install -r requirements.txt && \
-    pip install -r requirements.dev.txt && \
-    pip install jupyterlab
+    pip install -r requirements.dev.txt
 
 COPY . ./
 

--- a/README.md
+++ b/README.md
@@ -37,15 +37,12 @@ pip install https://github.com/altmetric/altmetric-explorer-api-client/tarball/m
 
 ## Getting Started
 
-A [docker compose](https://docs.docker.com/compose/) file is included to setup a development environment in docker that runs a Jupyter Labs server so you can experiment with the api.
-
+A [docker compose](https://docs.docker.com/compose/) file is included to setup a development environment.
 Start it by running:
 
 ```sh
 docker compose up # add the -d flag to run in the background
 ```
-
-Then visit http://localhost:8888/lab/tree/docs/getting_started.ipynb and follow the instructions in the notebook to learn how to use the API client.
 
 If you have any problems, a good first step is to re-start docker compose with the `--build` option so that the api container is re-built from scratch.
 

--- a/altmetric/explorer/api/client.py
+++ b/altmetric/explorer/api/client.py
@@ -43,7 +43,7 @@ def decode_value(value):
 FILTER_REGEXP = re.compile(r'filter\[(?P<field>\w+)\]')
 
 
-def api_encode(query_string):
+def create_api_client_query_dict(query_string):
     result = {}
     for key, value in urllib.parse.parse_qs(query_string).items():
         match str(key):
@@ -144,7 +144,7 @@ class Client:
             raise ValueError(
                 f'{url} must be a string or a urllib.parse.ParseResult')
 
-        encoded_query = api_encode(parsed_url.query)
+        encoded_query = create_api_client_query_dict(parsed_url.query)
         path = parsed_url.path.replace('/explorer/api/', '')
         return urllib.parse.unquote(self.urlfor(path, **encoded_query))
 

--- a/altmetric/explorer/api/client.py
+++ b/altmetric/explorer/api/client.py
@@ -1,6 +1,9 @@
 import base64
 import hashlib
 import hmac
+import re
+import urllib
+import sys
 
 import requests
 
@@ -21,6 +24,44 @@ def digest(secret, message):
     signature = base64.b64encode(hmac_sha1.digest()).decode('utf-8')
     signature = hmac_sha1.hexdigest()
     return signature
+
+
+def decode_value(value):
+    try:
+        obj = eval(str(value))
+        if type(obj) in (tuple, list, set):
+            if len(obj) > 1:
+                return [decode_value(item) for item in obj]
+            else:
+                return decode_value(obj[0])
+        else:
+            return int(obj)
+    except:
+        return str(value)
+
+
+FILTER_REGEXP = re.compile(r'filter\[(?P<field>\w+)\]')
+
+
+def api_encode(query_string):
+    result = {}
+    for key, value in urllib.parse.parse_qs(query_string).items():
+        match str(key):
+            case 'digest' | 'key':
+                next
+            case 'page[size]':
+                result['page_size'] = decode_value(value)
+            case 'page[number]':
+                result['page_number'] = decode_value(value)
+            case 'filter[order]':
+                result['order'] = decode_value(value)
+            case str() if re.match(FILTER_REGEXP, key):
+                filters = re.match(FILTER_REGEXP, key).groupdict()
+                result[filters['field']] = decode_value(value)
+            case _:
+                raise ValueError(f'Unexpected query parameter: {key}={value}')
+
+    return result
 
 
 class Client:
@@ -48,12 +89,29 @@ class Client:
         self.api_key = api_key
         self.api_secret = api_secret
 
-    def get(self, path, **args):
+    def urlfor(self, path, **vargs):
+        """
+        Constructs the URL for the specified API query with the given query parameters.
+
+        Args:
+            path (str): The path to query on the API endpoint.
+            **vargs: Filters and other query parameters as keyword arguments.
+
+        Returns:
+            str: The constructed URL.
+
+        """
+        query = Query(**vargs)
+        query.add_auth(self.api_key, digest(
+            self.api_secret, query.filters.message()))
+        return self.api_endpoint + '/' + path + '?' + str(query)
+
+    def get(self, path, **vargs):
         """Generic get method that constructs a call to an API path and returns a Response. An authentication digest is calculated behind the scenes using the
         api keys instance variables and the filters provided and added to the request automatically.
 
         Args:
-            path (string): the path to query
+            path (string): The path to query on the API endpoint.
             args (keyword list, accepts the following):
                 page_size (int, optional): size of each page to be returned. Defaults to 100.
                 order (string, optional): the field on which the results should be sorted. Defaults to None.
@@ -64,12 +122,31 @@ class Client:
         Returns:
             response: A Response object for the API call.
         """
-        query = Query(**args)
-        query.add_auth(self.api_key,
-                       digest(self.api_secret, query.filters.message()))
-        url = self.api_endpoint + '/' + path + '?' + str(query)
-
+        url = self.urlfor(path, **vargs)
         return Response(requests.get(url))
+
+    def recode_url(self, url):
+        '''Rebuilds a url using the attributes of the client to rewrite the hostname,
+        key and digest.  This is useful when you have generated new access keys or you
+        want to re-use a url created in someone else's account.
+
+        Args:
+            url (string or urllib.parse.ParseResult): the original url
+
+        Returns:
+            str: the new URL
+        '''
+        if type(url) is str:
+            parsed_url = urllib.parse.urlparse(url.replace('\\', ''))
+        elif type(url) is urllib.parse.ParseResult:
+            parsed_url = url
+        else:
+            raise ValueError(
+                f'{url} must be a string or a urllib.parse.ParseResult')
+
+        encoded_query = api_encode(parsed_url.query)
+        path = parsed_url.path.replace('/explorer/api/', '')
+        return urllib.parse.unquote(self.urlfor(path, **encoded_query))
 
     def get_attention_summary(self, **args):
         '''Shorthand accessor for research_outputs/attention'''

--- a/altmetric/explorer/api/test_api.py
+++ b/altmetric/explorer/api/test_api.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse, parse_qs
+
 import pytest
 
 from . import Client
@@ -66,3 +68,114 @@ def test_getting_the_response_block_from_the_meta_block(client_fn, expected_keys
     fn = getattr(api_client, client_fn)
     response = fn(page_size=1)  # return a tiny page so tests run quickly
     assert set(response.meta.keys()) == set(expected_keys)
+
+
+URL_EXAMPLES = [
+    (('https://altmetric.com/explorer/api/research_outputs/mentions'),
+     ('https://www.altmetric.com/explorer/api/research_outputs/mentions?'
+      'digest=aaabbb&'
+      'key=xxxxyyyy')
+     ),
+
+    (('research_outputs/mentions'),
+     ('https://www.altmetric.com/explorer/api/research_outputs/mentions?'
+      'digest=aaabbb&'
+      'key=xxxxyyyy')
+     ),
+
+    (('https://altmetric.com/explorer/api/research_outputs/mentions?'
+      'digest=6f4e3b50a2bc442199a2c32449b1754d&'
+      'key=xxxxyyyy'),
+     ('https://www.altmetric.com/explorer/api/research_outputs/mentions?'
+      'digest=aaabbb&'
+      'key=xxxxyyyy')
+     ),
+
+    (('https://altmetric.com/explorer/api/research_outputs/mentions?'
+      'digest=6f4e3b50a2bc442199a2c32449b1754d&'
+      'key=xxxxyyyy&'
+      'page[size]=10&page[number]=3'),
+     ('https://www.altmetric.com/explorer/api/research_outputs/mentions?'
+      'digest=aaabbb&'
+      'key=xxxxyyyy&'
+      'page[size]=10&page[number]=3'
+      )),
+
+    (('https://altmetric.com/explorer/api/research_outputs/mentions?'
+      'digest=6f4e3b50a2bc442199a2c32449b1754d&'
+      'key=xxxxyyyy&'
+      'page[size]=10&page[number]=3&'
+      'filter[order]=score_desc&'
+      'filter[type][]=book&'
+      'filter[type][]=chapter'
+      ),
+     ('https://www.altmetric.com/explorer/api/research_outputs/mentions?'
+      'digest=aaabbb&'
+      'key=xxxxyyyy&'
+      'page[size]=10&page[number]=3&'
+      'filter[order]=score_desc&'
+      'filter[type][]=book&'
+      'filter[type][]=chapter'
+      ))
+]
+
+
+@pytest.mark.parametrize('url,expected', URL_EXAMPLES)
+def test_recoding_a_url(mocker, api_client, url, expected):
+    mocker.patch('altmetric.explorer.api.client.digest', return_value='aaabbb')
+    api_client.api_key = 'xxxxyyyy'
+
+    result = urlparse(api_client.recode_url(url))
+    expected = urlparse(expected)
+
+    # Query params may be ordered differently between the result and expected urls
+    # even though they are semantically identical so it's easier to test the
+    # component parts of the url individually rather than trying to ensure
+    # the query strings are identical.
+    assert result.scheme == expected.scheme
+    assert result.hostname == expected.hostname
+    assert result.netloc == expected.netloc
+    assert result.path == expected.path
+    assert result.params == expected.params
+    assert result.fragment == expected.fragment
+    assert parse_qs(result.query) == parse_qs(expected.query)
+
+
+@pytest.mark.parametrize('url,expected', [
+    (urlparse(url), urlparse(expected)) for url, expected in URL_EXAMPLES]
+)
+def test_recoding_a_url_from_a_url_object(mocker, api_client, url, expected):
+    mocker.patch('altmetric.explorer.api.client.digest', return_value='aaabbb')
+    api_client.api_key = 'xxxxyyyy'
+
+    result = urlparse(api_client.recode_url(url))
+    expected = expected
+
+    # Query params may be ordered differently between the result and expected urls
+    # even though they are semantically identical so it's easier to test the
+    # component parts of the url individually rather than trying to ensure
+    # the query strings are identical.
+    assert result.scheme == expected.scheme
+    assert result.hostname == expected.hostname
+    assert result.netloc == expected.netloc
+    assert result.path == expected.path
+    assert result.params == expected.params
+    assert result.fragment == expected.fragment
+    assert parse_qs(result.query) == parse_qs(expected.query)
+
+
+@pytest.mark.parametrize('query_string', [
+    'wombat=1',
+    'wombat[value]=foo',
+    'wombat][=foo',
+])
+def test_recoding_a_url_rejects_invalid_query_string(api_client, query_string):
+    url = f'{api_client.api_endpoint}?{query_string}'
+
+    with pytest.raises(ValueError, match=r'(?i)unexpected query parameter.+wombat'):
+        urlparse(api_client.recode_url(url))
+
+
+def test_recoding_a_url_rejects_query_that_is_not_a_string(api_client):
+    with pytest.raises(ValueError, match=r'(?i)must be a string'):
+        urlparse(api_client.recode_url(1234))

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,5 +3,5 @@
 echo "INFO : Syncing .python-version with the container"
 printf '%s\n' $PYTHON_VERSION > .python-version
 
-echo "INFO : Starting jupyter lab at http://localhost:8888"
-jupyter lab --allow-root --no-browser --ip 0.0.0.0 --LabApp.token=''
+echo "INFO : Starting a daemon so the container stays alive"
+tail -f /dev/null

--- a/docs/api_client_endpoints.ipynb
+++ b/docs/api_client_endpoints.ipynb
@@ -8,28 +8,48 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 5,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The dotenv extension is already loaded. To reload it, use:\n",
-      "  %reload_ext dotenv\n"
-     ]
-    }
-   ],
    "source": [
-    "%load_ext dotenv\n",
-    "%dotenv\n",
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get your API key and secret from the Colab secrets.  \n",
     "\n",
-    "import os\n",
+    "Your API key and secret are available in your [Altmetric Explorer account](https://www.altmetric.com/explorer/settings).  Click the key icon on the left hand side of the Colab window and add them to your Colab account before running this step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.colab import userdata\n",
     "\n",
-    "API_KEY = os.getenv('API_KEY')\n",
-    "API_SECRET = os.getenv('API_SECRET')\n",
+    "API_KEY = userdata.get('API_KEY')\n",
+    "API_SECRET = userdata.get('API_SECRET')\n",
     "API_URL = 'https://www.altmetric.com/explorer/api'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Install the API client from GitHub."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/altmetric/altmetric-explorer-api-client/tarball/main"
    ]
   },
   {
@@ -41,20 +61,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "status: ok\n",
-      "description: All research outputs sorted by Altmetric Attention Score\n",
-      "total-results: 48099976\n",
-      "total-pages: 1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from altmetric.explorer import api\n",
     "\n",
@@ -75,20 +84,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "status: ok\n",
-      "description: All research outputs sorted by Altmetric Attention Score\n",
-      "total-results: 48099976\n",
-      "total-pages: 1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from altmetric.explorer import api\n",
     "\n",
@@ -109,20 +107,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "status: ok\n",
-      "description: All research outputs sorted by Altmetric Attention Score\n",
-      "total-results: 71728\n",
-      "total-pages: 1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from altmetric.explorer import api\n",
     "\n",
@@ -143,20 +130,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "status: ok\n",
-      "description: All research outputs sorted by Altmetric Attention Score\n",
-      "total-results: 242353082\n",
-      "total-pages: 9694124\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from altmetric.explorer import api\n",
     "\n",
@@ -177,21 +153,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "status: ok\n",
-      "description: All research outputs sorted by Altmetric Attention Score\n",
-      "total-results: 12877017\n",
-      "total-pages: 515081\n",
-      "total-mentions: 245180345\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from altmetric.explorer import api\n",
     "\n",
@@ -212,20 +176,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "status: ok\n",
-      "description: All research outputs sorted by Altmetric Attention Score\n",
-      "total-results: 48099976\n",
-      "total-pages: 1924000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from altmetric.explorer import api\n",
     "\n",

--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "You will find your api key and secret at https://www.altmetric.com/explorer/settings.\n",
     "\n",
-    "You can use whatever you like to your API key and secret but this notebook is designed to run in [Google Colab](https://colab.google/) and we are using the secrets store built into Colab to store the API key and secret securely.  To do this, open the \"Secrets\" by clicking the key icon on the left hand side of the page and make new secrets named `API_KEY` and `API_SECRET` and add the values from from you account settings in Explorer.\n",
+    "You can use whatever you like to store your API key and secret but this notebook is designed to run in [Google Colab](https://colab.google/) and we are using the secrets store built into Colab to store the API key and secret securely.  To do this, open the \"Secrets\" by clicking the key icon on the left hand side of the page and make new secrets named `API_KEY` and `API_SECRET` and add the values from from you account settings in Explorer.\n",
     "\n",
     "Go ahead and do it now and then run the cell below to load your keys into variables this notebook can use.  Colab may prompt you to authorise notebook access for each secret.  This is expected. Click \"Grant Access\" to continue."
    ]

--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -21,48 +21,23 @@
     "\n",
     "You will find your api key and secret at https://www.altmetric.com/explorer/settings.\n",
     "\n",
-    "You can use whatever you like to distribute secrets but, for the purposes of demonstrating how the API works, we are using [python-dotenv](https://pypi.org/project/python-dotenv/) and you must set it up with your own key and secret for the examples to work.\n",
+    "You can use whatever you like to your API key and secret but this notebook is designed to run in [Google Colab](https://colab.google/) and we are using the secrets store built into Colab to store the API key and secret securely.  To do this, open the \"Secrets\" by clicking the key icon on the left hand side of the page and make new secrets named `API_KEY` and `API_SECRET` and add the values from from you account settings in Explorer.\n",
     "\n",
-    "Simply create a file called `.env` in the project root directory and add the following lines using your own keys from https://www.altmetric.com/explorer/settings.\n",
-    "\n",
-    "```\n",
-    "API_KEY=xxxxxxxx\n",
-    "API_SECRET=yyyyyyy\n",
-    "```\n",
-    "\n",
-    "Go ahead and do it now and then run the cell below to load your keys into environment variables this notebook can access."
+    "Go ahead and do it now and then run the cell below to load your keys into variables this notebook can use.  Colab may prompt you to authorise notebook access for each secret.  This is expected. Click \"Grant Access\" to continue."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "3fc6d8fe-1a7a-4db8-a77c-4b8c00d5b3f7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext dotenv\n",
-    "%dotenv"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1ae22071-61e9-49a0-bd60-7b96ddbb89b6",
-   "metadata": {},
-   "source": [
-    "Now that `dotenv` has loaded your keys into the environment, you can assign them to Python variables."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "49006204-4402-4c3b-8461-abecaa94828c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
+    "from google.colab import userdata\n",
     "\n",
-    "API_KEY = os.getenv('API_KEY')\n",
-    "API_SECRET = os.getenv('API_SECRET')"
+    "API_KEY = userdata.get('API_KEY')\n",
+    "API_SECRET = userdata.get('API_SECRET')\n",
+    "API_URL = 'https://www.altmetric.com/explorer/api'"
    ]
   },
   {
@@ -75,15 +50,33 @@
   },
   {
    "cell_type": "markdown",
-   "id": "573544dc-ecd7-4260-8892-412865eaa05f",
+   "id": "1ee33b16",
    "metadata": {},
    "source": [
-    "First, import the `api` package and create a `Client` object using the API URL and your key and secret."
+    "First, use `pip` to install the API client from GitHub"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
+   "id": "f8a7b7a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/altmetric/altmetric-explorer-api-client/tarball/main"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "573544dc-ecd7-4260-8892-412865eaa05f",
+   "metadata": {},
+   "source": [
+    "Next, import the `api` package and create a `Client` object using the API URL and your key and secret."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "8b470b85-944b-472e-a651-6184d4a1d9e0",
    "metadata": {},
    "outputs": [],
@@ -119,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "0418a8b7-0d63-4839-b009-b29b00933c4b",
    "metadata": {},
    "outputs": [],
@@ -170,18 +163,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "22e1ca8a-466f-4744-be58-767b5f85fd97",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO : the API responded with status: 200\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('INFO : the API responded with status:', response.status_code)\n"
    ]
@@ -196,23 +181,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "1c8a3ead-02b7-4195-93a5-81aa54bc32a3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO : got metadata:\n",
-      "  status = 'ok'\n",
-      "  description = 'All research outputs sorted by Altmetric Attention Score mentioned in the past three days'\n",
-      "  total-results = 403\n",
-      "  total-pages = 5\n",
-      "  total-mentions = 3284\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "meta = response.meta\n",
     "print(f'INFO : got metadata:')\n",
@@ -234,27 +206,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "33d4cd07-0d8d-490f-8bd6-57411603f010",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'id': 'blog:85332', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': 'Nature Behind the Paper', 'image': None}, 'meta': {'mention-count': 278}}\n",
-      "{'id': 'blog:62498', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': 'Balkinization', 'image': None}, 'meta': {'mention-count': 235}}\n",
-      "{'id': 'blog:76592', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': 'Science Alert', 'image': None}, 'meta': {'mention-count': 120}}\n",
-      "{'id': 'blog:79222', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': 'information for practice - Journal Article Abstracts', 'image': None}, 'meta': {'mention-count': 103}}\n",
-      "{'id': 'blog:83410', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': 'news-medical.net', 'image': None}, 'meta': {'mention-count': 92}}\n",
-      "{'id': 'blog:53207', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': \"Physician's Weekly\", 'image': None}, 'meta': {'mention-count': 85}}\n",
-      "{'id': 'blog:82418', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': 'Psychology Today', 'image': None}, 'meta': {'mention-count': 69}}\n",
-      "{'id': 'blog:84582', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': 'Stemcell science news', 'image': None}, 'meta': {'mention-count': 59}}\n",
-      "{'id': 'blog:56095', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': 'Well - New York Times', 'image': None}, 'meta': {'mention-count': 59}}\n",
-      "{'id': 'blog:52139', 'type': 'profile', 'attributes': {'profile-type': 'blog', 'name': 'Slate Blogs', 'image': None}, 'meta': {'mention-count': 58}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from itertools import islice\n",
     "\n",
@@ -283,23 +238,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "74c88e06-b7e4-41a0-9bcf-09474c7630b3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://www.altmetric.com/explorer/api/research_outputs/mention_sources?filter[order]=profile-type&page[size]=100&key=b5f9faabd368491692d4209087ffacae&digest=788862429f1f577faacfb54c9bc9fa33075a4d98&filter[mention_sources_types][]=type:policy&filter[mention_sources_types][]=type:blog&filter[timeframe]=3d\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from urllib.parse import unquote\n",
     "\n",
     "print(unquote(response.raw_response.url))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42bc9dc9-4d1c-4c68-8768-70d412575bfb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -318,7 +273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,3 @@
-pytest
 autopep8
+pytest
+pytest-mock


### PR DESCRIPTION
Modifies the documentation notebooks so they run in Google Colab.  This was a case of making them get the API key and secret from Colab's secrets store and installing the api client using pip because we are no longer running the notebooks from the cloned repo.

Also adds a utility method that will re-write a URL using the user's key and secret.  This is useful when working on cases like documentation when a URL has stopped working because the original access keys have been deleted or replaced