### PR TITLE
Update API docs link to docs.altmetric.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Altmetric Explorer API Client
 
 A basic API client for extracting data from Altmetric Explorer using the Explorer
-API ([documentation here](https://explorer-api-docs.altmetric.com/)).  This is intended to be a starter for 10 to help you get going with the API
+API ([documentation here](https://docs.altmetric.com/explorer-api/)).  This is intended to be a starter for 10 to help you get going with the API
 and you are encouraged to build out whatever you need from here.
 
 A quick example:


### PR DESCRIPTION
Ticket: https://digital-science.atlassian.net/browse/CAP-714

The README was still linking to the old explorer-api-docs.altmetric.com. Update it to docs.altmetric.com/explorer-api/.